### PR TITLE
unit test for news api and code refactor

### DIFF
--- a/leadplus_news/urls.py
+++ b/leadplus_news/urls.py
@@ -19,6 +19,6 @@ from news.views import LatestNewsAPI, LatestNews
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path("", LatestNews.as_view(), name="latest_news_page"),
-    path("api/news_items/", LatestNewsAPI.as_view(), name="news_items_api"),
+    path("", LatestNews.as_view(), name="latest-news-page"),
+    path("api/news_items/", LatestNewsAPI.as_view(), name="news-items-api"),
 ]

--- a/news/apps.py
+++ b/news/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class NewsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'news'
+
+    def ready(self):
+        import news.signals  # import signals file

--- a/news/management/commands/fetch_news.py
+++ b/news/management/commands/fetch_news.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import hashlib
 import pytz
 import requests
 from django.core.management.base import BaseCommand
@@ -32,7 +31,6 @@ class Command(BaseCommand):
             description = news["description"]
             author = news["author"]
             url = news["url"]
-            md5 = hashlib.md5(url.encode('utf-8')).hexdigest()
             content = news["content"]
 
             # publishAt is a datetime string, eg. "2011-11-04T00:05:23Z"
@@ -42,13 +40,13 @@ class Command(BaseCommand):
             published_at = pytz.utc.localize(published_at)
 
             try:
-                NewsItem.objects.create(title=title,
-                                        description=description,
-                                        author=author,
-                                        url=url,
-                                        md5=md5,
-                                        content=content,
-                                        published_at=published_at)
+                news = NewsItem(title=title,
+                                description=description,
+                                author=author,
+                                url=url,
+                                content=content,
+                                published_at=published_at)
+                news.save()
                 articles_added += 1
             except IntegrityError:
                 self.stdout.write(self.style.WARNING(
@@ -58,3 +56,5 @@ class Command(BaseCommand):
                     f"Article ignored, invalid url:{url}"))
         self.stdout.write(self.style.SUCCESS(
             "%d news items successfully fetched and %d added in the database." % (len(news_items), articles_added)))
+
+

--- a/news/signals.py
+++ b/news/signals.py
@@ -1,0 +1,9 @@
+import hashlib
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+from .models import NewsItem
+
+@receiver(pre_save, sender=NewsItem)
+def calculate_md5(sender, instance, **kwargs):
+    md5_hash = hashlib.md5(instance.url.encode('utf-8')).hexdigest()
+    instance.md5 = md5_hash

--- a/news/templates/news/base.html
+++ b/news/templates/news/base.html
@@ -9,8 +9,8 @@
     <header>
       <nav class="navbar">
         <a href="#">Leadplus News</a>
-        <a href="{% url 'latest_news_page' %}">Latest News</a>
-        <a href="{% url 'news_items_api' %}">News API</a>
+        <a href="{% url 'latest-news-page' %}">Latest News</a>
+        <a href="{% url 'news-items-api' %}">News API</a>
       </nav>
     </header>
     <main>

--- a/news/tests.py
+++ b/news/tests.py
@@ -1,3 +1,49 @@
-from django.test import TestCase
+import hashlib
+import pytz
+from io import StringIO
+from datetime import datetime, timezone, timedelta
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.core.management import call_command
+from unittest.mock import patch, MagicMock
+from rest_framework import status
+from rest_framework.test import APIClient
+from .models import NewsItem
+from .serializers import NewsItemSerializer
 
-# Create your tests here.
+
+class NewsItemSignalTestCase(TestCase):
+    def test_calculate_md5(self):
+        utc_tz = pytz.timezone('UTC')
+        news = NewsItem.objects.create(
+            title="Test News",
+            author="Test Author",
+            description="Test Description",
+            url="http://www.example.com/test-news",
+            content="Test Content",
+            published_at=datetime.now(utc_tz),
+        )
+        self.assertIsNotNone(news.md5)
+        md5_hash = hashlib.md5(news.url.encode('utf-8')).hexdigest()
+        self.assertEqual(news.md5, md5_hash)
+
+
+class LatestNewsAPITest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse('news-items-api')
+
+        # create some news items for testing
+        now = datetime.now(timezone.utc)
+        NewsItem.objects.create(title='News 1', url='http://example.com/1', published_at=now - timedelta(days=2))
+        NewsItem.objects.create(title='News 2', url='http://example.com/2', published_at=now - timedelta(days=1))
+        NewsItem.objects.create(title='News 3', url='http://example.com/3', published_at=now - timedelta(hours=1))
+
+    def test_get_latest_news(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # check that the latest 100 news items are returned, ordered by published_at descending
+        expected_queryset = NewsItem.objects.order_by('-published_at')[:100]
+        expected_data = NewsItemSerializer(expected_queryset, many=True).data
+        self.assertEqual(response.data, expected_data)


### PR DESCRIPTION
1. use signal to trigger NewsItems's md5 field calculation, fetch_news.py updated accordingly
2. unit test for md5 calculation
3. unit test for news api
4. url naming updated to comply with django's practise